### PR TITLE
Fix broken URL :-)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A brief description for the Pivotal Legacy Org
 
 
-Due to larger efforts, this Org (previously called /pivotal), is actively being migrated to the new Pivotal consolidated org at: https//github.com/pivotal.
+Due to larger efforts, this Org (previously called /pivotal), is actively being migrated to the new Pivotal consolidated org at: https://github.com/pivotal
 
 Please do not let the name deceive you: **until moved, all repos in this org are still being actively worked on in this org**.
 


### PR DESCRIPTION
Add missing colon (:) to URL
From
https//github.com/pivotal
to
https://github.com/pivotal